### PR TITLE
Fix UnicodeDecodeError in Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import find_packages, setup
+from io import open
 
 
 setup(
     name='camel',
     version='0.1',
     description="Python serialization for adults",
-    long_description=open('README.txt').read(),
+    long_description=open('README.txt', encoding='utf8').read(),
     url="https://github.com/eevee/camel",
     author="Eevee (Lexy Munroe)",
     author_email="eevee.camel@veekun.com",


### PR DESCRIPTION
That dash in the readme causes Python 3 builds to fail.

`Traceback (most recent call last):` 
`  File "setup.py", line 8, in <module>` 
`    long_description=open('README.txt').read(),` 
`  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode` 
`    return codecs.ascii_decode(input, self.errors)[0]` 
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 93: ordinal not in range(128)`

This PR fixes that.