### PR TITLE
Add LICENSE and README.txt to the source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.txt


### PR DESCRIPTION
This would allow to create conda-packages from the source distribution.

A note, I find it a little confusing to have a `README.txt` and a `README.rst` which is a link to the txt file. Wouldn't be better to just have a `README.rst` file instead?